### PR TITLE
Two commits together from the official repo > my fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 build/*.js
 build/*.js.map
 gh-pages/
+.idea

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
   "dependencies": {
     "benchmark": "^1.0.0",
     "d3": "^3.5.6",
+    "events": "^1.1.0",
     "lodash": "^3.10.1",
     "queue-async": "^1.0.7",
+    "react": "^0.14.2",
+    "react-dom": "^0.14.2",
     "svg-transform": "0.0.3"
   },
   "scripts": {

--- a/src/react/actions.js
+++ b/src/react/actions.js
@@ -1,0 +1,6 @@
+import { actionTypes } from './constants';
+import { dispatch } from './store';
+
+export function setOption( property, value ) {
+	dispatch( { type: actionTypes.SET_OPTION, property, value } );
+}

--- a/src/react/app.jsx
+++ b/src/react/app.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import { getState, hook } from './store';
+import Histogram from './histogram';
+
+export default React.createClass( {
+	componentDidMount() {
+		this.setState( {
+			unhook: hook( this.updateState )
+		} );
+	},
+
+	componentWillUnmount() {
+		this.state.unhook();
+	},
+
+	updateState() {
+		this.setState( { state: getState() } );
+	},
+
+	render() {
+		return (
+			<div id="synteny-app" className="_synteny-dotplot-builder">
+				<canvas id="dotplot-canvas-bak" className="dotplot" />
+				<canvas id="dotplot-canvas" className="dotplot" />
+				<svg id="dotplot" className="dotplot" />
+
+				<Histogram />
+			</div>
+		);
+	}
+} );

--- a/src/react/constants.js
+++ b/src/react/constants.js
@@ -1,0 +1,3 @@
+export const actionTypes = Object.freeze( {
+	SET_OPTION: Symbol()
+} );

--- a/src/react/form.jsx
+++ b/src/react/form.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { setOption } from './actions';
+
+export default React.createClass( {
+	render() {
+		const { title, property, options, selectedOption } = this.props;
+
+		return (
+			<div className="radio-button-box">
+				<strong>{ title }</strong>
+
+				<form id={ property }>
+					{ options.map( ( [ value, label ], index ) => (
+						<span key={ `input-${ index }` }>
+							<label>{ label }</label>
+							<input
+								type="radio"
+								name={ property }
+								value={ value }
+								checked={ value === selectedOption }
+								onChange={ () => setOption( property, value ) }
+							/>
+						</span>
+					) ) }
+				</form>
+			</div>
+		);
+	}
+} );

--- a/src/react/histogram.jsx
+++ b/src/react/histogram.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import OptionsDialog from './options-dialog';
+
+export default React.createClass( {
+	render() {
+		return (
+			<div id="histogram-wrapper">
+				<svg id="plot" className="histogram" />
+				<svg id="plot2" className="histogram" />
+				<svg id="plot3" className="histogram" />
+
+				<OptionsDialog />
+			</div>
+		);
+	}
+} );

--- a/src/react/options-dialog.jsx
+++ b/src/react/options-dialog.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import { setOption } from './actions';
+import { getState } from './store';
+import Form from './form';
+
+const formData = [
+	{
+		title: 'Navigation Mode',
+		property: 'mouse-options',
+		options: [ option( 'brush', 'Brushing' ), option( 'pan', 'Panning' ) ],
+	}, {
+		title: 'Plotting order',
+		property: 'summary-options',
+		options: [ option( 'minimum', 'High to Low' ), option( 'maximum', 'Low to High' ) ]
+	}, {
+		title: 'Dot Plot Coloring',
+		property: 'plot-var-options',
+		options: [
+			option( 'logks', 'log ks' ),
+			option( 'logkn', 'log kn' ),
+			option( 'logkskn', 'log ks/kn' )
+		]
+	}, {
+		title: 'Color Scale',
+		property: 'colorOptions',
+		options: [
+			option( 'rg', 'red-green' ),
+			option( 'rg_quantized', 'rg_quantized' ),
+			option( 'rainbow', 'rainbow' ),
+			option( 'rainbow_quantized', 'rainbow_quantized' ),
+			option( 'auto', 'auto' )
+		]
+	}
+];
+
+function option( value, text ) {
+	return [ value, text ];
+}
+
+export default React.createClass( {
+	render() {
+		const state = getState();
+
+		return (
+			<div id="form-wrapper">
+				{ formData.map( form => (
+					<Form key={ `form-${ form.property }` } {...{ ...form, selectedOption: state[ form.property ] } } />
+				) ) }
+
+				<div className="radio-button-box">
+					<strong>Auto-scale persistence</strong>
+
+					<input
+						id="persistence"
+						{...{ type: 'range', min: 0, max: 100, step: 1, value: state.persistence } }
+						onChange={ e => setOption( 'persistence', e.target.value ) }
+					/>
+					<button id="persistence-button" type="button">Refresh auto scale</button>
+
+					<p>Largest persistence edge that will be removed: <label id="persistence-text">{ state.persistence }</label></p>
+				</div>
+			</div>
+		);
+	}
+} );

--- a/src/react/store.js
+++ b/src/react/store.js
@@ -1,0 +1,48 @@
+import eventsFactory from 'events';
+const emitter = new eventsFactory.EventEmitter();
+
+import { actionTypes } from './constants';
+
+const initialState = {
+	'mouse-options': 'brush',
+	'summary-options': 'minimum',
+	'plot-var-options': 'logks',
+	colorOptions: 'rg',
+	persistence: 40
+};
+
+let state = clearState();
+
+function clearState() {
+	return Object.assign( {}, initialState );
+}
+
+function emit() {
+	emitter.emit( 'change' );
+}
+
+export function hook( callback ) {
+	emitter.on( 'change', callback );
+
+	return () => emitter.off( 'change', callback );
+}
+
+export function getState() {
+	return state;
+}
+
+export function dispatch( action ) {
+	let oldState = state;
+
+	switch ( action.type ) {
+		case actionTypes.SET_OPTION:
+			state = Object.assign( {}, state, { [ action.property ]: action.value } );
+			break;
+		default:
+			break;
+	}
+
+	if ( oldState !== state ) {
+		emit();
+	}
+}

--- a/src/synteny-vis.js
+++ b/src/synteny-vis.js
@@ -1,5 +1,12 @@
 'use strict';
 
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { setOption } from 'react/actions';
+import { getState } from 'react/store';
+import App from 'react/app';
+
 const histogram = require('histogram');
 const dotplot = require('dotplot');
 const _ = require('lodash');
@@ -8,111 +15,38 @@ const autoscale = require('auto-colorscale');
 
 require('style.css');
 
-const { 
-	RUN_BENCHMARKS, 
-	SHOW_MAXIMA_AND_MINIMA 
+const {
+	RUN_BENCHMARKS,
+	SHOW_MAXIMA_AND_MINIMA
 } = require('constants');
 
-function buildDiv(element_id) {
-	const div = d3.select(element_id).append('div').classed('_synteny-dotplot-builder', true);
-
-	div.append('canvas').attr('id', 'dotplot-canvas-bak').classed('dotplot', true);
-	div.append('canvas').attr('id', 'dotplot-canvas').classed('dotplot', true);
-	div.append('svg').attr('id', 'dotplot').classed('dotplot', true);
-
-	const histogramWrapper = div.append('div').attr('id', 'histogram-wrapper');
-	histogramWrapper.append('svg').attr('id', 'plot').classed('histogram', true);
-	histogramWrapper.append('svg').attr('id', 'plot2').classed('histogram', true);
-	histogramWrapper.append('svg').attr('id', 'plot3').classed('histogram', true);
-
-	const formWrapper = div.append('div').attr('id', 'form-wrapper');
-
-	function makeForm(title, optionId, elements, checkIndex) {
-		const navOptions = formWrapper.append('div').classed('radio-button-box', true);
-		navOptions.append('strong').text(title + ': ');
-
-		const navForm = navOptions.append('form').attr('id', optionId);
-		const options = navForm.selectAll('input')
-			.data(elements).enter().append('input')
-			.attr('type', 'radio').attr('name', optionId)
-			.attr('value', d => d[0]);
-
-		options.forEach(selection => {
-			selection.forEach((element, i) => {
-				const label = document.createElement('label');
-				label.textContent = elements[i][1];
-				navForm.node().insertBefore(label, element);
-			});
-		});
-
-		options[0][checkIndex].checked = true;
-	}
-
-	const option = (value, text) => [value, text];
-
-	makeForm('Navigation Mode', 'mouse-options', [
-		option('brush', 'Brushing'),
-		option('pan', 'Panning')
-	], 0);
-
-	makeForm('Plotting order', 'summary-options', [
-		option('minimum', 'High to Low'),
-		option('maximum', 'Low to High')
-	], 0);
-
-	makeForm('Dot Plot Coloring', 'plot-var-options', [
-		option('logks', 'log ks'),
-		option('logkn', 'log kn'),
-		option('logkskn', 'log ks/kn')
-	], 0);
-
-	makeForm('Color Scale', 'color-options', [
-		option('rg', 'red-green'),
-		option('rg_quantized', 'rg_quantized'),
-		option('rainbow', 'rainbow'),
-		option('rainbow_quantized', 'rainbow_quantized'),
-		option('auto', 'auto')
-	], 0);
-
-	const persistenceOptions = formWrapper.append('div').classed('radio-button-box', true);
-	persistenceOptions.append('strong').text('Auto-scale persistence');
-
-	persistenceOptions.append('input').attr('id', 'persistence').attr('type', 'range').attr('min', 0).attr('max', 100)
-		.attr('value', 40).attr('step', 1);
-
-	persistenceOptions.append('button').attr('id', 'persistence-button').attr('type', 'button').text('Refresh auto scale');
-
-	persistenceOptions.append('p').text('Largest persistence edge that will be removed: ').append('label').attr('id', 'persistence-text').text('40');
-}
-
 function controller(dataObj, element_id, meta) {
+	ReactDOM.render( React.createElement( App ), document.getElementById( element_id ) );
 
-	buildDiv('#' + element_id);
-	
-	const refreshAutoScale = (persistence) => {
-		const radio = document.getElementById('color-options');
-		const auto = _.find(radio.children, child => child.value === 'auto');
-		auto.checked = true;
+	const refreshAutoScale = () => {
+		const { persistence } = getState();
 
 		const h = histograms[activeField];
 		h.setColorScale(autoscale.generateAutoScale(h.bins(), persistence));
 
 		if (SHOW_MAXIMA_AND_MINIMA)
 			_.each(histograms, h => h.updateMinMaxMarkers(persistence));
+
+		// TODO: Fix this so we can run it syncronously without
+		//       messing up the form onChange handlers
+		setTimeout( () => setOption( 'colorOptions', 'auto' ), 100 );
 	};
 
-	const getPersistence = () => d3.select('#persistence').node().value;
+	const getPersistence = () => getState().persistence;
 
 	d3.select('#persistence')
 		.on('input', () => {
-			const p = getPersistence();
-			refreshAutoScale(p);
-			d3.select('#persistence-text').node().innerText = p;
+			refreshAutoScale();
 		});
 
 	d3.select('#persistence-button')
 		.on('click', () => {
-			refreshAutoScale(getPersistence());
+			refreshAutoScale();
 		});
 
 	/* zoom/pan switching */
@@ -146,7 +80,7 @@ function controller(dataObj, element_id, meta) {
 	/* color mode switching */
 	var activeField = 'logks';
 	var activeCS = 'rg';
-	d3.selectAll('#color-options input[name=color-options]')
+	d3.selectAll('#colorOptions input[name=colorOptions]')
 		.on('change', function() {
 			var newCS;
 			if (this.value === 'auto') {
@@ -171,8 +105,8 @@ function controller(dataObj, element_id, meta) {
 		'logkskn': histogram.histogram('#plot3', dataObj, 'logkskn', unselected)
 	};
 
-	// Since the histograms aren't controlling their own color scale policy 
-	// now (a good thing), we need to manually fire of their update methods. 
+	// Since the histograms aren't controlling their own color scale policy
+	// now (a good thing), we need to manually fire of their update methods.
 	// Eventually, we should fix this up.
 	dataObj.addListener((typeHint) => {
 		if(typeHint.indexOf('stop') > -1)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,24 +1,24 @@
 module.exports = {
-  entry: __dirname + '/src/main.js',
-  output: {
-    path: __dirname + '/build',
-    filename: 'synteny-dotplot-builder.js'
-  },
-  module: {
-    loaders: [
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        loader: 'babel-loader'
-      }, { 
-				test: /\.css$/, 
-				loader: "style-loader!css-loader" 
+	entry: __dirname + '/src/main.js',
+	output: {
+		path: __dirname + '/build',
+		filename: 'synteny-dotplot-builder.js'
+	},
+	module: {
+		loaders: [
+			{
+				test: /\.jsx?$/,
+				exclude: /node_modules/,
+				loader: 'babel-loader'
+			}, {
+				test: /\.css$/,
+				loader: "style-loader!css-loader"
 			}
 		]
-  },
-  resolve: {
-    modulesDirectories: ['src', 'node_modules'],
-    extensions: ['', '.js']
-  },
-  devtool: 'sourcemap'
+	},
+	resolve: {
+		modulesDirectories: [ 'src', 'node_modules' ],
+		extensions: [ '', '.js', '.jsx' ]
+	},
+	devtool: 'sourcemap'
 };


### PR DESCRIPTION
## Adds a minimal install of React

Although this doesn't do much, it pulls in the React library and starts
handing the render tasks over to React.

It caused some linter errors which meant that `npm run build-production`
failed, but the errors came about because of the ES6 import syntax. This
is a linter issue.

## Contintue Reacting, add basic Flux store/actions

At 414 KB this is still bigger, but it has to get worse before it gets
better.

Splitting off the functionality is messy here because of the
entanglement between the data, the display, and the events. Once
everything can be modularized it should all make much more sense. Right
now, however, it's a mixture of React and d3 doing the same thing and
that's messy.

Eventually most of the stuff that `synteny-vis.js` seems to be intended
for will move into `<App />` as the top-of-the-hierarchy app logic.
Things like the histogram code don't belong there and they will need to
eventually move into the histogram module.

I have already shuffled most of the options config dialog code out of
`synteny-vis.js` and into `<OptionsDialog />`. This seemed to fit since
that form is all app-specific, but it builds the dialog form the
slightly-more-generic and mostly modular reincarnation of `makeForm()` -
`<Form />`.

As of now, I _believe_ that this is at feature-parity with **master**.