### PR TITLE
Remove hard-coded GEvo sequence comparison link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,12 @@ makeSyntenyDotplots({
   genome_y: {
     ...                  // same as above
   }
+
+  gen_coge_seq_link: function(aId, bId) {
+    // Create a URL for a CoGe sequence comparison. This will override the
+    // default link generation scheme, which defaults to
+    // 'http://genomevolution.org/coge/GEvo.pl?fid1=42;fid2=24;apply_all=50000;num_seqs=2'
+    return 'https://www.google.com#q=' + aId + '+' + bId;
+  }
 });
 ```

--- a/src/coge-util.js
+++ b/src/coge-util.js
@@ -38,6 +38,23 @@ exports.computeBaseUrl = computeBaseUrl;
 /*
  * Generate a link to a sequence comparison page on CoGe for a pair of
  * chromosomes, identified by their CoGe database IDs.
+ *
+ * Note: This function will attempt to generate a link apropriate to the
+ * current URL using computeBaseUrl (See computeBaseUrl for details).
  */
-exports.genCogeSequenceLink = (id1, id2, loc = window.location) =>
-    computeBaseUrl(loc) + `/GEvo.pl?fid1=${id1};fid2=${id2};apply_all=50000;num_seqs=2`;
+exports.genCogeSequenceLink = (id1, id2) =>
+    computeBaseUrl(window.location) + `/GEvo.pl?fid1=${id1};fid2=${id2};apply_all=50000;num_seqs=2`;
+
+/*
+ * Fetch a GEvo feature description over HTTP. Returns a promise that
+ * resolves to a json object upon success.
+ *
+ * Note: This function will attempt to fetch from the API endpoint at the
+ * same origin as the current URL using computeBaseUrl (See computeBaseUrl
+ * for details).
+ */
+exports.getSingleFeatureDescription = (dbId) => {
+  const base = computeBaseUrl(window.location)
+  return fetch(base + `/api/v1/features/${dbId}`)
+    .then(response => response.json());
+}

--- a/src/coge-util.js
+++ b/src/coge-util.js
@@ -1,8 +1,43 @@
-const BASE_URL = 'http://genomevolution.org/coge/';
+/*
+ * Compute the effective "base" of the coge site url. This is not
+ * quite the same as `window.location.origin`, since we include elements of
+ * the pathname that seem to be constant for many site pages, i.e.,
+ *
+ * "https://genomevolution.org/coge/"
+ *
+ * Instead of
+ *
+ * https://genomevolution.org
+ *
+ * This lets coge developers use this function unmodified during
+ * development in sandboxes, but if working locally we re-direct to
+ * the official endpoints.
+ *
+ * The parameter is a Location like object.
+ */
+const BASE_PATH_FOR_DEV = 'https://genomevolution.org/coge';
+
+const computeBaseUrl = loc => {
+
+  const path = loc.origin + loc.pathname;
+  if(path.endsWith('/SynMap.pl')) {
+    return path.substring(0, path.length - '/SynMap.pl'.length);
+  }
+
+  if(loc.hostname !== 'localhost') {
+    console.log(`Warning: Not sure how to convert the current href ` +
+                `"${loc.href}" into a "base" URL. Using ` +
+                `"${BASE_PATH_FOR_DEV}" instead.`);
+  }
+
+  return BASE_PATH_FOR_DEV;
+}
+
+exports.computeBaseUrl = computeBaseUrl;
 
 /*
  * Generate a link to a sequence comparison page on CoGe for a pair of
  * chromosomes, identified by their CoGe database IDs.
  */
-exports.genCogeSequenceLink = (id1, id2) =>
-    BASE_URL + `GEvo.pl?fid1=${id1};fid2=${id2};apply_all=50000;num_seqs=2`;
+exports.genCogeSequenceLink = (id1, id2, loc = window.location) =>
+    computeBaseUrl(loc) + `/GEvo.pl?fid1=${id1};fid2=${id2};apply_all=50000;num_seqs=2`;

--- a/src/coge-util.js
+++ b/src/coge-util.js
@@ -31,7 +31,7 @@ const computeBaseUrl = loc => {
   }
 
   return BASE_PATH_FOR_DEV;
-}
+};
 
 exports.computeBaseUrl = computeBaseUrl;
 
@@ -42,8 +42,10 @@ exports.computeBaseUrl = computeBaseUrl;
  * Note: This function will attempt to generate a link apropriate to the
  * current URL using computeBaseUrl (See computeBaseUrl for details).
  */
-exports.genCogeSequenceLink = (id1, id2) =>
-    computeBaseUrl(window.location) + `/GEvo.pl?fid1=${id1};fid2=${id2};apply_all=50000;num_seqs=2`;
+exports.genCogeSequenceLink = (id1, id2) => {
+  const base = computeBaseUrl(window.location);
+  return base + `/GEvo.pl?fid1=${id1};fid2=${id2};apply_all=50000;num_seqs=2`;
+};
 
 /*
  * Fetch a GEvo feature description over HTTP. Returns a promise that
@@ -54,7 +56,7 @@ exports.genCogeSequenceLink = (id1, id2) =>
  * for details).
  */
 exports.getSingleFeatureDescription = (dbId) => {
-  const base = computeBaseUrl(window.location)
+  const base = computeBaseUrl(window.location);
   return fetch(base + `/api/v1/features/${dbId}`)
     .then(response => response.json());
-}
+};

--- a/src/coge-util.js
+++ b/src/coge-util.js
@@ -1,0 +1,8 @@
+const BASE_URL = 'http://genomevolution.org/coge/';
+
+/*
+ * Generate a link to a sequence comparison page on CoGe for a pair of
+ * chromosomes, identified by their CoGe database IDs.
+ */
+exports.genCogeSequenceLink = (id1, id2) =>
+    BASE_URL + `GEvo.pl?fid1=${id1};fid2=${id2};apply_all=50000;num_seqs=2`;

--- a/src/coge-util.test.js
+++ b/src/coge-util.test.js
@@ -1,0 +1,38 @@
+import should from 'should';
+
+import { computeBaseUrl } from '../src/coge-util';
+
+describe('computeBaseUrl', function() {
+
+  it('should derive from known urls correctly', function() {
+
+    computeBaseUrl({
+      origin: 'https://genomevolution.org',
+      hostname: 'genomevolution.org',
+      pathname: '/coge/SynMap.pl'
+    }).should.equal('https://genomevolution.org/coge');
+
+    computeBaseUrl({
+      origin: 'https://geco.iplantc.org',
+      hostname: 'geco.iplantc.org',
+      pathname: '/coge/SynMap.pl'
+    }).should.equal('https://geco.iplantc.org/coge');
+
+    computeBaseUrl({
+      origin: 'https://geco.iplantc.org',
+      hostname: 'geco.iplantc.org',
+      pathname: '/asherkhb/coge/SynMap.pl'
+    }).should.be.exactly('https://geco.iplantc.org/asherkhb/coge');
+
+  });
+
+  it('should map localhost onto coge', function() {
+
+    computeBaseUrl({
+      hostname: 'localhost',
+      pathname: '/index.html'
+    }).should.be.exactly('https://genomevolution.org/coge');
+
+  });
+
+});

--- a/src/coge-util.test.js
+++ b/src/coge-util.test.js
@@ -22,7 +22,7 @@ describe('computeBaseUrl', function() {
       origin: 'https://geco.iplantc.org',
       hostname: 'geco.iplantc.org',
       pathname: '/asherkhb/coge/SynMap.pl'
-    }).should.be.exactly('https://geco.iplantc.org/asherkhb/coge');
+    }).should.equal('https://geco.iplantc.org/asherkhb/coge');
 
   });
 
@@ -31,7 +31,7 @@ describe('computeBaseUrl', function() {
     computeBaseUrl({
       hostname: 'localhost',
       pathname: '/index.html'
-    }).should.be.exactly('https://genomevolution.org/coge');
+    }).should.equal('https://genomevolution.org/coge');
 
   });
 

--- a/src/dotplot.js
+++ b/src/dotplot.js
@@ -75,10 +75,6 @@ function synteny(id, dataObj, field, initialColorScale, meta) {
     }, []);
   };
 
-  const genGeVOLink = (aDbId, bDbId) =>
-    'http://geco.iplantcollaborative.org/asherkhb/coge/GEvo.pl?' +
-    `fid1=${aDbId};fid2=${bDbId};apply_all=${50000};num_seqs=${2}`;
-
   const getSingleGeVoDescription = id =>
   fetch(`https://genomevolution.org/coge/api/v1/features/${id}`)
     .then(r => r.json());
@@ -107,7 +103,9 @@ function synteny(id, dataObj, field, initialColorScale, meta) {
       d3.select('#gevo-link')
         .text('Compare in GEvo >>>')
         .attr('onclick', () => {
-          const link = genGeVOLink(point.x_feature_id, point.y_feature_id);
+          const { x_feature_id, y_feature_id } = point;
+          const { gen_coge_seq_link } = meta;
+          const link = gen_coge_seq_link(x_feature_id, y_feature_id);
           return `window.open('${link}')`;
         });
       getGeVODescription(point.x_feature_id, point.y_feature_id)

--- a/src/dotplot.js
+++ b/src/dotplot.js
@@ -1,6 +1,7 @@
 import utils from './utils';
 import d3 from 'd3';
 import transform from 'svg-transform';
+import { getSingleFeatureDescription } from './coge-util';
 const { minBy, zipObject, zipWith } = utils;
 
 import {
@@ -75,13 +76,10 @@ function synteny(id, dataObj, field, initialColorScale, meta) {
     }, []);
   };
 
-  const getSingleGeVoDescription = id =>
-  fetch(`https://genomevolution.org/coge/api/v1/features/${id}`)
-    .then(r => r.json());
 
-  const getGeVODescription = (aDbId, bDbId) => Promise.all([
-    getSingleGeVoDescription(aDbId),
-    getSingleGeVoDescription(bDbId)
+  const getFeatureDescription = (aDbId, bDbId) => Promise.all([
+    getSingleFeatureDescription(aDbId),
+    getSingleFeatureDescription(bDbId)
   ])
     .then(([x, y]) => {
       return {x_name: x.names.join(', '), y_name: y.names.join(', ')};
@@ -108,7 +106,7 @@ function synteny(id, dataObj, field, initialColorScale, meta) {
           const link = gen_coge_seq_link(x_feature_id, y_feature_id);
           return `window.open('${link}')`;
         });
-      getGeVODescription(point.x_feature_id, point.y_feature_id)
+      getFeatureDescription(point.x_feature_id, point.y_feature_id)
         .then(({x_name, y_name}) => {
           d3.select('#gevo-link-xname')
             .text(`${meta.x_name}: ${x_name}`);

--- a/src/main.js
+++ b/src/main.js
@@ -3,12 +3,14 @@ import queue from 'd3-queue';
 import sv from './synteny-vis';
 import crossfilter from 'crossfilter';
 import { timeIt, zipObject } from './utils';
+import { genCogeSequenceLink } from './coge-util';
 
 exports.makeSyntenyDotPlot = function({
     data_url,
     element_id,
     genome_x,
-    genome_y
+    genome_y,
+    gen_coge_seq_link = genCogeSequenceLink
   }) {
   queue.queue()
     .defer(d3.text, data_url)
@@ -37,7 +39,14 @@ exports.makeSyntenyDotPlot = function({
 
       const ksDataObject = createDataObj(inlinedKSData, xCumLenMap, yCumLenMap);
       console.log('Total synteny dots:', ksDataObject.currentData().raw.length);
-      sv.controller(ksDataObject, element_id, {x_name, y_name, have_ks});
+
+      const meta = {
+        x_name,
+        y_name,
+        have_ks,
+        gen_coge_seq_link
+      };
+      sv.controller(ksDataObject, element_id, meta);
     });
 };
 


### PR DESCRIPTION
Previously, pressing the sequence comparison button linked to Asher's development environment, which isn't remotely OK. Now it points at the right place, and can be overridden by the user.

#### Testing

To test the default behavior: visit this [branch](http://hdc-arizona.github.io/synteny-vis/#h), select a point, click the "Compare in GEvo button," and make sure you go to CoGe proper.

To test the override: At the call site for `makeSyntenyDotPlot`, add the `gen_coge_seq_link` parameters. Before:

```javascript
makeSyntenyDotPlot({
  element_id: 'main',
    data_url: selected.data_url,
    genome_x: genome_x,
    genome_y: genome_y
});
```

after

```javascript
makeSyntenyDotPlot({
  element_id: 'main',
    data_url: selected.data_url,
    genome_x: genome_x,
    genome_y: genome_y,
    gen_coge_seq_link: function(aId, bId) {
      return 'https://www.google.com#q=' + aId + '+' + bId;
    }
});
```

Confirm that you get redirected to the link that you specified.

Closes #41 