### PR TITLE
Clean up color interpolation

### DIFF
--- a/src/auto-colorscale.js
+++ b/src/auto-colorscale.js
@@ -42,7 +42,8 @@ const generateColorScaleFromExtrema = extrema => {
 
   return d3.scale.linear()
            .domain(pairs.map(d => d.midpoint))
-           .range(pairs.map(d => d.color));
+           .range(pairs.map(d => d.color))
+           .interpolate(d3.interpolateLab);
 };
 
 /* Local Variables:  */

--- a/src/auto-colorscale.js
+++ b/src/auto-colorscale.js
@@ -10,58 +10,39 @@ exports.generateAutoScale = (points, persistence) => {
   return generateColorScaleFromExtrema(extrema);
 };
 
-const isMaxima = (A, i) => A[i].y > Math.max(A[i - 1].y, A[i + 1].y);
-const shouldBeMarked = (x, i, A) => {
-  // This is bad, but we are special casing the first maximum if it is "big."
-  // This gives the ks == 0 spike color.
-  if(i == 0 && A[i].y >= 0.5 * Math.max(...A.map(x => x.y))) {
-    return true;
-  }
-  // common case: normal maxima
-  return i > 0 && i < A.length - 1 && isMaxima(A, i);
-};
+const isMaximum = (A, i) => (i === 0 || A[i].y > A[i - 1].y) &&
+                           (i === A.length - 1 || A[i].y > A[i + 1].y);
 
 const generateColorScaleFromExtrema = extrema => {
   const colors = d3.scale.category10();
-  // function calls into d3 colorscales mutate the object, which
-  // means that the calls are order-dependent, which means
-  // we need to "prime" the colormap here with the right calls
 
-  var markedColors = [];
-  var markedColorByIndex = {};
-  extrema.forEach((x, i, A) => {
-    if (shouldBeMarked(x,i,A)) {
-      markedColorByIndex[i] = markedColors.length;
-      markedColors.push(colors(i));
-    }
-  });
+  // We rely on the fact that every other point is a maximum.
+  for(let i = 0; i < extrema.length - 1; i++) {
+    if(isMaximum(extrema, i) == isMaximum(extrema, i + 1))
+      console.error('Invariant violated, extrema are', extrema);
+  }
 
-  // FIXME: this is an embarrassing amount of work to write "compute
-  // the color in between two consecutive steps in the colormap".
-  const colored = extrema.map((x, i, A) => {
-    var color;
-    if (shouldBeMarked(x, i, A)) {
-      color = colors(i);
-    } else if (i === 0) {
-      color = markedColors[0];
-    } else {
-      var valleyLeft = d3.lab(markedColors[markedColorByIndex[i-1]]);
-      var valleyRight = d3.lab(
-        markedColors[Math.min(markedColorByIndex[i-1]+1,
-                              markedColors.length-1)]);
-      color = d3.lab(0.5 * (valleyLeft.l + valleyRight.l),
-                     0.5 * (valleyLeft.a + valleyRight.a),
-                     0.5 * (valleyLeft.b + valleyRight.b));
-    }
-    var result = Object.assign({}, x);
-    result.color = color;
-    return result;
-  });
+  // Function calls on colorscales mutate the object, but since we call the
+  // function with monotonically non-decreasing indices and the scale remembers
+  // the colors it assigned to indices before, we are safe here.
+  const pairs = extrema
+    .map((d, i, A) => {
+      var color;
+      if (isMaximum(A, i)) {
+        color = colors(i);
+      } else if(i === 0) {
+        color = colors(i + 1);
+      } else if(i === A.length - 1) {
+        color = colors(i - 1);
+      }
 
-  const domain = colored.map(d => d.x + d.dx / 2);
-  const range = colored.map(x => x.color);
+      return { midpoint: d.x + d.dx / 2, color };
+    })
+    .filter(({ color }) => color !== undefined);
 
-  return d3.scale.linear().domain(domain).range(range);
+  return d3.scale.linear()
+           .domain(pairs.map(d => d.midpoint))
+           .range(pairs.map(d => d.color));
 };
 
 /* Local Variables:  */


### PR DESCRIPTION
Cleans up the manual interpolation that was added to fix the valley coloring.

This also removes the heuristic I added way back to ensure the `ks == 0` peak was colored. That means that the 0 peak may be colored now when it wasn't before. I can't readily demonstrate this with the current test data, so perhaps that is a rare scenario. In any case, the logic for selecting peaks to color is simpler.

~Colors that are adjacent in `d3.scale.category10()` are adjacent in the final histogram (just like current master). Since that is a categorical color scale, it isn't clear to me if this is something we need to maintain -- I can't tell if the scale itself was [designed to be used that way](https://github.com/d3/d3-scale#schemeCategory10). We can remove some more code if we don't care about this. @cscheid ?~
(It no longer helps remove any code, so not a pressing concern).